### PR TITLE
feat(listeners): add link tracking

### DIFF
--- a/prisma/migrations/20221205155136_add_link_tracking/migration.sql
+++ b/prisma/migrations/20221205155136_add_link_tracking/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "channel" ADD COLUMN     "linksSent" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "guild" ADD COLUMN     "linksSent" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "member" ADD COLUMN     "linksSent" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Guild {
 	everyoneMentions Int @default(0)
 	invitesCreated Int @default(0)
 	invitesDeleted Int @default(0)
+	linksSent Int @default(0)
 	membersJoined Int @default(0)
 	membersLeft Int @default(0)
 	membersTimedOut Int @default(0)
@@ -69,6 +70,7 @@ model Channel {
 	everyoneMentions Int @default(0)
 	roleMentions Int @default(0)
 	userMentions Int @default(0)
+	linksSent Int @default(0)
 }
 
 model Member {
@@ -86,6 +88,7 @@ model Member {
 	mentionedByOthers Int @default(0)
 	roleMentions Int @default(0)
 	userMentions Int @default(0)
+	linksSent Int @default(0)
 	scheduledEventsSubscribed Int @default(0)
 	scheduledEventsUnsubscribed Int @default(0)
 }

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -4,3 +4,5 @@
  * @remark Capture group 1 is the Snowflake. It is named `id`.
  */
  export const SnowflakeRegex = /(?<id>\d{17,20})/;
+
+ export const LinkRegex = /https?:\/\//g;

--- a/src/listeners/guilds/messages/messageCreate.ts
+++ b/src/listeners/guilds/messages/messageCreate.ts
@@ -1,4 +1,4 @@
-import { SnowflakeRegex } from "#utils/constants";
+import { LinkRegex, SnowflakeRegex } from "#utils/constants";
 import { ApplyOptions } from "@sapphire/decorators";
 import { FormattedCustomEmoji } from "@sapphire/discord-utilities";
 import { Events, Listener, ListenerOptions } from "@sapphire/framework";
@@ -21,6 +21,9 @@ export class UserListener extends Listener {
 		await this.totalMentions(message);
 		await this.channelMentions(message);
 		await this.memberMentions(message);
+		await this.totalLinks(message);
+		await this.channelLinks(message);
+		await this.memberLinks(message);
 	}
 
 	private async totalMessages(message: Message) {
@@ -379,6 +382,51 @@ export class UserListener extends Listener {
 				data: {
 					roleMentions: {
 						increment: message.mentions.roles.size
+					}
+				}
+			});
+		}
+	}
+
+	private async totalLinks(message: Message) {
+		const parsedLinks = message.content.match(LinkRegex);
+		
+		if (parsedLinks?.length) {
+			await this.container.client.prisma.guild.update({
+				where: { id: message.guild?.id },
+				data: {
+					linksSent: {
+						increment: parsedLinks.length
+					}
+				}
+			});
+		}
+	}
+
+	private async channelLinks(message: Message) {
+		const parsedLinks = message.content.match(LinkRegex);
+		
+		if (parsedLinks?.length) {
+			await this.container.client.prisma.channel.update({
+				where: { id: message.channel?.id },
+				data: {
+					linksSent: {
+						increment: parsedLinks.length
+					}
+				}
+			});
+		}
+	}
+
+	private async memberLinks(message: Message) {
+		const parsedLinks = message.content.match(LinkRegex);
+		
+		if (parsedLinks?.length) {
+			await this.container.client.prisma.member.update({
+				where: { id: message.author?.id },
+				data: {
+					linksSent: {
+						increment: parsedLinks.length
 					}
 				}
 			});


### PR DESCRIPTION
Adds tracking for links globally, per-channel, and per-member.

Regex just looks for `http://` or `https://`, didn't think it would be necessary to overcomplicate it further than that.