### PR TITLE
refactor: couple changes to ensure db data, minor change to export command

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -195,11 +195,11 @@ export class UserCommand extends Command {
 		];
 
 		for (const entry of memberDb) {
-			const member = this.container.client.users.cache.get(entry.id);
+			const member = await this.container.client.users.fetch(entry.id);
 			
 			const row = [
 				entry.id,
-				member ? member?.username : 'Member unavailable or left server',
+				member ? member.username : 'Member unavailable or left server',
 				entry.messages,
 				entry.messagesDeleted,
 				entry.messagesUpdated,

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -199,7 +199,7 @@ export class UserCommand extends Command {
 			
 			const row = [
 				entry.id,
-				member ? member.username : 'Member unavailable or left server',
+				member.username || 'Member unavailable or left server',
 				entry.messages,
 				entry.messagesDeleted,
 				entry.messagesUpdated,

--- a/src/listeners/guilds/channels/channelCreate.ts
+++ b/src/listeners/guilds/channels/channelCreate.ts
@@ -1,10 +1,13 @@
 import { ApplyOptions } from "@sapphire/decorators";
 import { Events, Listener, ListenerOptions } from "@sapphire/framework";
+import { bold } from "colorette";
 import { GuildTextBasedChannel } from "discord.js";
 
 @ApplyOptions<ListenerOptions>({ event: Events.ChannelCreate })
 export class UserListener extends Listener {
 	public async run(channel: GuildTextBasedChannel) {
+		await this.initializeChannel(channel);
+
 		await this.container.client.prisma.guild.update({
 			where: { id: String(channel.guild.id) },
 			data: {
@@ -13,5 +16,21 @@ export class UserListener extends Listener {
 				}
 			}
 		});
+	}
+
+	private async initializeChannel(channel: GuildTextBasedChannel) {
+		const channelDb = await this.container.client.prisma.channel.findFirst({ where: { id: channel.id } });
+		if (!channelDb) {
+			this.container.logger.info(`Initializing entry for channel ${bold(channel.id)}...`);
+
+			await this.container.client.prisma.channel.create({
+				data: {
+					id: channel.id
+				}
+			}).catch(e => {
+				this.container.logger.error(`Failed to initialize channel ${bold(channel.id)}, error below.`);
+				this.container.logger.error(e);
+			});
+		}
 	}
 }

--- a/src/listeners/guilds/members/guildMemberAdd.ts
+++ b/src/listeners/guilds/members/guildMemberAdd.ts
@@ -1,10 +1,13 @@
 import { ApplyOptions } from "@sapphire/decorators";
 import { Events, Listener, ListenerOptions } from "@sapphire/framework";
+import { bold } from "colorette";
 import { GuildMember } from "discord.js";
 
 @ApplyOptions<ListenerOptions>({ event: Events.GuildMemberAdd })
 export class UserListener extends Listener {
 	public async run(member: GuildMember) {
+		await this.initializeMember(member);
+
 		await this.container.client.prisma.guild.update({
 			where: { id: String(member.guild.id) },
 			data: {
@@ -13,5 +16,21 @@ export class UserListener extends Listener {
 				}
 			}
 		});
+	}
+
+	private async initializeMember(member: GuildMember) {
+		const memberDb = await this.container.client.prisma.member.findFirst({ where: { id: member.id } });
+		if (!memberDb) {
+			this.container.logger.info(`Initializing entry for member ${bold(member.id)}...`);
+
+			await this.container.client.prisma.member.create({
+				data: {
+					id: member.id
+				}
+			}).catch(e => {
+				this.container.logger.error(`Failed to initialize member ${bold(member.id)}, error below.`);
+				this.container.logger.error(e);
+			});
+		}
 	}
 }


### PR DESCRIPTION
- Adds method to initialize channels in database on the `channelCreate` event.
- Adds method to clear channels in database on the `channelDelete` event.
- Fixes issue where `export` command would print `Member unavailable or left server` for almost all entries.